### PR TITLE
Add resolution parameter to initIMGUI

### DIFF
--- a/src/private/gui.cpp
+++ b/src/private/gui.cpp
@@ -1,13 +1,16 @@
 
 #include "../public/gui.h"
+void TurboGUI::GUI::initIMGUI(uint resolutionX, uint resolutionY){
+    TurboGUI::GUI::initIMGUI(ImVec2(resolutionX, resolutionY));
+}
 
-void TurboGUI::GUI::initIMGUI() {
+void TurboGUI::GUI::initIMGUI(const ImVec2& resolution) {
     context = ImGui::CreateContext();
 
     ImGuiIO& io = ImGui::GetIO();
     ImGui::StyleColorsDark();
     io.Fonts->AddFontDefault();
-    io.DisplaySize = ImVec2(1920, 1080);
+    io.DisplaySize = resolution;
 
     std::memset(drawTimeMean.data(), 0.f, drawTimeMean.size() * sizeof(float));
 

--- a/src/public/gui.h
+++ b/src/public/gui.h
@@ -42,7 +42,8 @@ namespace TurboGUI {
 
 	public:
 		/* set up ImGui fonts and style after calling this */
-		void initIMGUI();
+		void initIMGUI(const ImVec2& resolution);
+		void initIMGUI(uint resolutionX, uint resolutionY);
 		void initGL(uint, uint);
 		/* use ImGui::GetIO() to set up mouse and keyboard inputs before calling this */
 		void begin();


### PR DESCRIPTION
The imgui resolution now has to be manually set instead of defaulting to FullHD. Feel free to change the uint parameters to another type; I wouldn't though. I also wouldn't put any default value, it makes little sense.